### PR TITLE
update to 0.9.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.5
 MAINTAINER "Christophe Gasmi <cga@oxalide.com>"
-ENV TERRAFORM_VERSION=0.9.7
+ENV TERRAFORM_VERSION=0.9.8
 RUN apk add --update --no-cache curl git bash wget graphviz ttf-freefont
 ADD https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip ./
 RUN unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip -d /bin && rm -f terraform_${TERRAFORM_VERSION}_linux_amd64.zip


### PR DESCRIPTION
0.9.8 (June 7, 2017)

NOTE:

The 0.9.7 release had a bug with its new feature of periodically persisting state to the backend during an apply, as part of [#14834]. This change has been reverted in this release and will be re-introduced at a later time once it has been made to work properly.
IMPROVEMENTS:

provider/google: network argument in google_compute_instance_group is now optional (#13493)
provider/google: Add support for draining_timeout_sec to google_compute_backend_service. (#14559)
BUG FIXES:

provider/aws: fixed reading network configurations for spot_fleet_request (#13748)